### PR TITLE
feat: intro-modal UI 생성 

### DIFF
--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -1,22 +1,47 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import "./styles/PracticePage.css";
 import PracticeTabs from "./components/PracticeTabs";
 import ScriptPanel from "./components/ScriptPanel";
 import MetricCard from "./components/MetricCard";
 import RecordButton from "./components/RecordButton";
-import type { PracticeStage } from "./types";
+import PracticeIntroModal from "./components/PracticeIntroModal";
+import type { IntroFormState, PracticeStage } from "./types";
+
+const initialForm: IntroFormState = {
+  audienceAge: "",
+  audienceKnowledge: "",
+  speechType: "",
+  duration: "",
+};
+
+const PRACTICE_TABS = ["스피치 모드", "프레젠테이션 모드"] as const;
 
 export default function PracticePage() {
-  const PRACTICE_TABS = ["스피치 모드", "프레젠테이션 모드"] as const;
-  const [stage, setStage] = useState<PracticeStage>("ready");
+  const [stage, setStage] = useState<PracticeStage>("intro-modal");
   const [activeTab, setActiveTab] = useState<string>(PRACTICE_TABS[0]);
+  const [introForm, setIntroForm] = useState<IntroFormState>(initialForm);
+
+  const isIntroComplete = useMemo(() => {
+    return (
+      !!introForm.audienceAge &&
+      !!introForm.audienceKnowledge &&
+      !!introForm.speechType &&
+      !!introForm.duration.trim()
+    );
+  }, [introForm]);
 
   const handleStartRecord = () => {
+    if (stage === "intro-modal") return;
     setStage("recording");
   };
 
   const handleStopRecord = () => {
     setStage("record-finished");
+  }
+  
+  const handleConfirmIntro = () => {
+    if (!isIntroComplete) return;
+    setStage("ready");
   };
 
   return (
@@ -75,6 +100,16 @@ BirthDateField`}
           onStart={handleStartRecord}
           onStop={handleStopRecord}
         />
+
+        {/* 인트로 모달 */}
+        {stage === "intro-modal" && (
+          <PracticeIntroModal
+            form={introForm}
+            onChange={setIntroForm}
+            onConfirm={handleConfirmIntro}
+            isConfirmEnabled={isIntroComplete}
+          />
+        )}
       </main>
     </div>
   );

--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -22,11 +22,15 @@ export default function PracticePage() {
   const [introForm, setIntroForm] = useState<IntroFormState>(initialForm);
 
   const isIntroComplete = useMemo(() => {
+    const durationNumber = Number(introForm.duration);
+
     return (
       !!introForm.audienceAge &&
       !!introForm.audienceKnowledge &&
       !!introForm.speechType &&
-      !!introForm.duration.trim()
+      !!introForm.duration.trim() &&
+      durationNumber >= 1 &&
+      durationNumber <= 60
     );
   }, [introForm]);
 

--- a/src/pages/practice/components/PracticeIntroModal.tsx
+++ b/src/pages/practice/components/PracticeIntroModal.tsx
@@ -1,0 +1,137 @@
+import type { IntroFormState } from "../types";
+
+type PracticeIntroModalProps = {
+  form: IntroFormState;
+  onChange: (next: IntroFormState) => void;
+  onConfirm: () => void;
+  isConfirmEnabled: boolean;
+};
+
+const ageOptions = ["어린이", "청소년", "성인", "노년"] as const;
+const knowledgeOptions = ["잘 모름", "보통", "잘 앎"] as const;
+const speechOptions = ["발표", "면접", "토론", "강의", "피드백 연습"] as const;
+
+export default function PracticeIntroModal({
+  form,
+  onChange,
+  onConfirm,
+  isConfirmEnabled,
+}: PracticeIntroModalProps) {
+  const updateField = <K extends keyof IntroFormState>(
+    key: K,
+    value: IntroFormState[K]
+  ) => {
+    onChange({
+      ...form,
+      [key]: value,
+    });
+  };
+
+  return (
+    <div className="practice-modal-overlay">
+      <div
+        className="practice-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="practice-intro-title"
+      >
+        <div className="practice-modal__header">
+          <h2 id="practice-intro-title">청중 및 스피치 정보를 입력해 주세요</h2>
+          <p>원활한 피드백 제공을 위해 청중과 스피치 정보를 입력해주세요.</p>
+        </div>
+
+        <div className="practice-modal__body">
+          <section className="practice-modal__section">
+            <h3>청중 정보</h3>
+
+            <div className="practice-modal__field">
+              <p>청중의 연령대는 어떻게 되나요?</p>
+              <div className="practice-modal__option-grid practice-modal__option-grid--4">
+                {ageOptions.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className={`practice-chip ${
+                      form.audienceAge === option ? "is-selected" : ""
+                    }`}
+                    onClick={() => updateField("audienceAge", option)}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="practice-modal__field">
+              <p>청중이 발표 주제를 얼마나 이해하고 있나요?</p>
+              <div className="practice-modal__option-grid practice-modal__option-grid--3">
+                {knowledgeOptions.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className={`practice-chip ${
+                      form.audienceKnowledge === option ? "is-selected" : ""
+                    }`}
+                    onClick={() => updateField("audienceKnowledge", option)}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="practice-modal__section">
+            <h3>스피치 정보</h3>
+
+            <div className="practice-modal__field">
+              <p>어떤 내용의 스피치를 하나요?</p>
+              <div className="practice-modal__option-grid practice-modal__option-grid--5">
+                {speechOptions.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    className={`practice-chip ${
+                      form.speechType === option ? "is-selected" : ""
+                    }`}
+                    onClick={() => updateField("speechType", option)}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="practice-modal__field">
+              <p>총 몇 분의 발표인가요?</p>
+              <div className="practice-modal__duration">
+                <input
+                  type="number"
+                  min="1"
+                  inputMode="numeric"
+                  value={form.duration}
+                  onChange={(e) => updateField("duration", e.target.value)}
+                  className="practice-modal__duration-input"
+                />
+                <span>분</span>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div className="practice-modal__footer">
+          <button
+            type="button"
+            className={`practice-modal__confirm ${
+              isConfirmEnabled ? "is-enabled" : ""
+            }`}
+            onClick={onConfirm}
+            disabled={!isConfirmEnabled}
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/practice/components/PracticeIntroModal.tsx
+++ b/src/pages/practice/components/PracticeIntroModal.tsx
@@ -19,12 +19,35 @@ export default function PracticeIntroModal({
 }: PracticeIntroModalProps) {
   const updateField = <K extends keyof IntroFormState>(
     key: K,
-    value: IntroFormState[K]
+    value: IntroFormState[K],
   ) => {
     onChange({
       ...form,
       [key]: value,
     });
+  };
+
+  const updateDuration = (value: string) => {
+    if (value === "") {
+      updateField("duration", "");
+      return;
+    }
+
+    const numericValue = Number(value);
+
+    if (Number.isNaN(numericValue)) return;
+
+    if (numericValue < 1) {
+      updateField("duration", "1");
+      return;
+    }
+
+    if (numericValue > 60) {
+      updateField("duration", "60");
+      return;
+    }
+
+    updateField("duration", value);
   };
 
   return (
@@ -108,9 +131,10 @@ export default function PracticeIntroModal({
                 <input
                   type="number"
                   min="1"
+                  max="60"
                   inputMode="numeric"
                   value={form.duration}
-                  onChange={(e) => updateField("duration", e.target.value)}
+                  onChange={(e) => updateDuration(e.target.value)}
                   className="practice-modal__duration-input"
                 />
                 <span>분</span>

--- a/src/pages/practice/styles/PracticePage.css
+++ b/src/pages/practice/styles/PracticePage.css
@@ -297,3 +297,175 @@
     flex-direction: column;
   }
 }
+
+.practice-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(25, 25, 25, 0.34);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 300;
+}
+
+.practice-modal {
+  width: 100%;
+  max-width: 760px;
+  background: #fff;
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.12);
+}
+
+.practice-modal__header {
+  padding: 44px 40px 30px;
+  background: #f6f6f6;
+  text-align: center;
+}
+
+.practice-modal__header h2 {
+  margin: 0 0 10px;
+  font-size: 24px;
+  font-weight: 800;
+  color: #202020;
+}
+
+.practice-modal__header p {
+  margin: 0;
+  font-size: 16px;
+  color: #8a8a8a;
+}
+
+.practice-modal__body {
+  padding: 32px 40px 12px;
+}
+
+.practice-modal__section {
+  margin-bottom: 28px;
+}
+
+.practice-modal__section h3 {
+  margin: 0 0 14px;
+  font-size: 22px;
+  font-weight: 800;
+  color: #202020;
+}
+
+.practice-modal__field {
+  margin-bottom: 22px;
+}
+
+.practice-modal__field p {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: #555;
+}
+
+.practice-modal__option-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.practice-modal__option-grid--4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.practice-modal__option-grid--3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.practice-modal__option-grid--5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
+.practice-chip {
+  height: 52px;
+  border: 1px solid #d9d9d9;
+  border-radius: 14px;
+  background: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.practice-chip.is-selected {
+  border-color: #58cabd;
+  background: #eefaf8;
+  color: #23998d;
+}
+
+.practice-modal__duration {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.practice-modal__duration-input {
+  width: 76px;
+  height: 48px;
+  border: 1px solid #d9d9d9;
+  border-radius: 12px;
+  padding: 0 12px;
+  font-size: 18px;
+  color: #222;
+  outline: none;
+}
+
+.practice-modal__duration-input:focus {
+  border-color: #58cabd;
+}
+
+.practice-modal__footer {
+  display: flex;
+  justify-content: center;
+  padding: 8px 40px 34px;
+}
+
+.practice-modal__confirm {
+  min-width: 164px;
+  height: 52px;
+  border: none;
+  border-radius: 999px;
+  background: #cfd7d6;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+  cursor: not-allowed;
+}
+
+.practice-modal__confirm.is-enabled {
+  background: #58cabd;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .practice-modal {
+    max-width: 92vw;
+    border-radius: 24px;
+  }
+
+  .practice-modal__header {
+    padding: 32px 20px 22px;
+  }
+
+  .practice-modal__body {
+    padding: 24px 20px 8px;
+  }
+
+  .practice-modal__section h3 {
+    font-size: 20px;
+  }
+
+  .practice-modal__option-grid--4,
+  .practice-modal__option-grid--3,
+  .practice-modal__option-grid--5 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .practice-modal__footer {
+    padding: 8px 20px 24px;
+  }
+}


### PR DESCRIPTION
## 📌 작업 내용
- practice mode 진입 시 intro-modal 화면 구현
- intro-modal 화면 확인 시 state를 intro-modal 로 변경해야합니다.

## 🔗 관련 이슈
- close #19 

## 🧪 테스트 방법
- [ ] npm run dev
- [ ] 주요 페이지 확인

## ✅ 체크리스트
- [ ] 빌드 에러 없음
- [ ] 코드 컨벤션 준수
- [ ] 불필요한 콘솔 제거

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/b095e933-8aa9-4277-b34d-1eb3658ad598



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an introductory modal that appears at the start of practice sessions to collect audience age, audience knowledge, speech type, and duration before recording.
  * Confirm button only enables when all fields are valid; duration input is constrained to 1–60 minutes.
  * Modal includes accessible dialog attributes, selectable option chips, responsive layout, and polished styling for desktop and mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->