### PR TITLE
Feat: style-modal 화면 생성

### DIFF
--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -5,8 +5,9 @@ import ScriptPanel from "./components/ScriptPanel";
 import MetricCard from "../../components/common/MetricCard/MetricCard";
 import RecordButton from "./components/RecordButton";
 import PracticeIntroModal from "./components/PracticeIntroModal";
+import PracticeStyleModal from "./components/PracticeStyleModal";
 import useAudioMeter from "./hooks/useAudioMeter";
-import type { IntroFormState, PracticeStage } from "./types";
+import type { IntroFormState, PracticeStage, SpeechStyleId } from "./types";
 
 const initialForm: IntroFormState = {
   audienceAge: "",
@@ -34,7 +35,7 @@ const SCRIPT_TEXT = `안녕하세요. 저희는 발표 연습을 돕는 웹 서�
 `;
 
 export default function PracticePage() {
-  const [stage, setStage] = useState<PracticeStage>("ready");
+  const [stage, setStage] = useState<PracticeStage>("intro-modal");
   const [activeTab, setActiveTab] = useState<string>(PRACTICE_TABS[0]);
   const [introForm, setIntroForm] = useState<IntroFormState>(initialForm);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
@@ -122,7 +123,8 @@ export default function PracticePage() {
   }, [elapsedSeconds]);
 
   const recordingStatusText = useMemo(() => {
-    if (stage === "intro-modal" || stage === "ready") return "녹음 전";
+    if (stage === "intro-modal" || stage === "style-modal" || stage === "ready")
+      return "녹음 전";
     if (stage === "recording") return "녹음 중";
     if (stage === "paused") return "일시정지";
     if (stage === "record-finished") return "녹음 완료";
@@ -142,6 +144,17 @@ export default function PracticePage() {
 
   const handleConfirmIntro = () => {
     if (!isIntroComplete) return;
+    setStage("style-modal");
+  };
+
+  const handlePreviewStyleTts = (styleId: SpeechStyleId) => {
+    // TODO: 백엔드 TTS 연동 시 선택한 styleId에 맞는 가이드 음성을 재생
+    console.log("TTS preview style", styleId);
+  };
+
+  const handleConfirmStyle = (styleId: SpeechStyleId) => {
+    // TODO: 백엔드 연동 시 선택한 styleId를 연습 세션 생성 요청에 포함
+    console.log("Selected speech style", styleId);
     setStage("ready");
   };
 
@@ -279,6 +292,14 @@ export default function PracticePage() {
             onChange={setIntroForm}
             onConfirm={handleConfirmIntro}
             isConfirmEnabled={isIntroComplete}
+          />
+        )}
+
+        {stage === "style-modal" && (
+          <PracticeStyleModal
+            recommendedStyle="passionate"
+            onPreviewTts={handlePreviewStyleTts}
+            onConfirm={handleConfirmStyle}
           />
         )}
 

--- a/src/pages/practice/components/PracticeIntroModal.tsx
+++ b/src/pages/practice/components/PracticeIntroModal.tsx
@@ -152,7 +152,7 @@ export default function PracticeIntroModal({
             onClick={onConfirm}
             disabled={!isConfirmEnabled}
           >
-            확인
+            다음
           </button>
         </div>
       </div>

--- a/src/pages/practice/components/PracticeStyleModal.tsx
+++ b/src/pages/practice/components/PracticeStyleModal.tsx
@@ -45,6 +45,9 @@ export default function PracticeStyleModal({
 }: PracticeStyleModalProps) {
   const [selectedStyle, setSelectedStyle] =
     useState<SpeechStyleId>(recommendedStyle);
+  const recommendedOption =
+    speechStyleOptions.find((option) => option.id === recommendedStyle) ??
+    speechStyleOptions[0];
 
   const handlePreviewTts = (styleId: SpeechStyleId) => {
     // TODO: 백엔드 TTS 연동 시 styleId를 기준으로 가이드 음성을 재생
@@ -61,7 +64,7 @@ export default function PracticeStyleModal({
       >
         <div className="practice-modal__header practice-modal__header--style">
           <p>입력하신 스피치 데이터를 바탕으로 추천하는 스타일이에요.</p>
-          <h2 id="practice-style-title">열정적인 스타일</h2>
+          <h2 id="practice-style-title">{recommendedOption.title}</h2>
         </div>
 
         <div className="practice-style-modal__body">

--- a/src/pages/practice/components/PracticeStyleModal.tsx
+++ b/src/pages/practice/components/PracticeStyleModal.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import type { SpeechStyleId } from "../types";
+
+type SpeechStyleOption = {
+  id: SpeechStyleId;
+  title: string;
+  description: string;
+  badge?: string;
+};
+
+type PracticeStyleModalProps = {
+  recommendedStyle?: SpeechStyleId;
+  onPreviewTts?: (styleId: SpeechStyleId) => void;
+  onConfirm: (styleId: SpeechStyleId) => void;
+};
+
+const speechStyleOptions: SpeechStyleOption[] = [
+  {
+    id: "passionate",
+    title: "열정적인 스타일",
+    description: "에너지가 느껴지는 전달",
+    badge: "추천",
+  },
+  {
+    id: "intellectual",
+    title: "지적인 스타일",
+    description: "효율적이고 전문적인 전달",
+  },
+  {
+    id: "calm",
+    title: "차분한 스타일",
+    description: "안정적이고 신뢰감이 느껴지는 전달",
+  },
+  {
+    id: "dynamic",
+    title: "전달력 있는 스타일",
+    description: "높낮이 변화와 강조",
+  },
+];
+
+export default function PracticeStyleModal({
+  recommendedStyle = "passionate",
+  onPreviewTts,
+  onConfirm,
+}: PracticeStyleModalProps) {
+  const [selectedStyle, setSelectedStyle] =
+    useState<SpeechStyleId>(recommendedStyle);
+
+  const handlePreviewTts = (styleId: SpeechStyleId) => {
+    // TODO: 백엔드 TTS 연동 시 styleId를 기준으로 가이드 음성을 재생
+    onPreviewTts?.(styleId);
+  };
+
+  return (
+    <div className="practice-modal-overlay">
+      <div
+        className="practice-modal practice-modal--style"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="practice-style-title"
+      >
+        <div className="practice-modal__header practice-modal__header--style">
+          <p>입력하신 스피치 데이터를 바탕으로 추천하는 스타일이에요.</p>
+          <h2 id="practice-style-title">열정적인 스타일</h2>
+        </div>
+
+        <div className="practice-style-modal__body">
+          <div className="practice-style-modal__intro">
+            <h3>어떤 스타일로 연습하시겠어요?</h3>
+            <p>스피커 아이콘을 누르면 가이드 TTS를 먼저 들어볼 수 있어요.</p>
+          </div>
+
+          <div className="practice-style-grid">
+            {speechStyleOptions.map((option) => {
+              const isSelected = selectedStyle === option.id;
+
+              return (
+                <div
+                  key={option.id}
+                  className={`practice-style-card ${
+                    isSelected ? "is-selected" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="practice-style-card__speaker"
+                    aria-label={`${option.title} TTS 듣기`}
+                    onClick={() => handlePreviewTts(option.id)}
+                  >
+                    <svg
+                      viewBox="0 0 32 32"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path d="M5 12.5h5l7-6v19l-7-6H5z" />
+                      <path d="M21 11.5c2 2.4 2 6.6 0 9" />
+                      <path d="M25 8c3.8 4.4 3.8 11.6 0 16" />
+                    </svg>
+                  </button>
+
+                  {option.badge && (
+                    <span className="practice-style-card__badge">
+                      {option.badge}
+                    </span>
+                  )}
+
+                  <button
+                    type="button"
+                    className="practice-style-card__select"
+                    aria-pressed={isSelected}
+                    onClick={() => setSelectedStyle(option.id)}
+                  >
+                    <strong>{option.title}</strong>
+                    <span>{option.description}</span>
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="practice-style-modal__footer">
+          <button
+            type="button"
+            className="practice-modal__confirm is-enabled"
+            onClick={() => onConfirm(selectedStyle)}
+          >
+            연습하러 가기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/practice/styles/PracticePage.css
+++ b/src/pages/practice/styles/PracticePage.css
@@ -509,6 +509,10 @@
   box-shadow: 0 20px 48px rgba(0, 0, 0, 0.12);
 }
 
+.practice-modal--style {
+  max-width: 720px;
+}
+
 .practice-modal__header {
   padding: 44px 40px 30px;
   background: #f6f6f6;
@@ -526,6 +530,21 @@
   margin: 0;
   font-size: 16px;
   color: #8a8a8a;
+}
+
+.practice-modal__header--style {
+  padding: 34px 40px 43px;
+}
+
+.practice-modal__header--style h2 {
+  margin: 8px 0 0;
+  font-size: 32px;
+  font-weight: 500;
+  color: #0e0e0e;
+}
+
+.practice-modal__header--style p {
+  font-size: 17px;
 }
 
 .practice-modal__body {
@@ -636,6 +655,128 @@
   cursor: pointer;
 }
 
+.practice-style-modal__body {
+  padding: 46px 86px 0;
+}
+
+.practice-style-modal__intro {
+  margin-bottom: 30px;
+}
+
+.practice-style-modal__intro h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 800;
+  color: #162033;
+}
+
+.practice-style-modal__intro p {
+  margin: 0;
+  font-size: 14px;
+  color: #7b8495;
+}
+
+.practice-style-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 22px;
+}
+
+.practice-style-card {
+  position: relative;
+  min-height: 146px;
+  border: 2px solid #e1e4e9;
+  border-radius: 18px;
+  background: #fff;
+  padding: 24px 30px 22px;
+  color: #1b2434;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.practice-style-card.is-selected {
+  border-color: #52cdbd;
+  background: #effbf8;
+  color: #16a894;
+  box-shadow: 0 10px 24px rgba(82, 205, 189, 0.12);
+}
+
+.practice-style-card__speaker {
+  width: 42px;
+  height: 42px;
+  border: none;
+  background: transparent;
+  color: #2d3748;
+  padding: 0;
+  margin: 0 0 12px;
+  cursor: pointer;
+}
+
+.practice-style-card.is-selected .practice-style-card__speaker {
+  color: #22b8a7;
+}
+
+.practice-style-card__speaker svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.practice-style-card__badge {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  padding: 5px 13px;
+  border-radius: 999px;
+  background: #d6f7ef;
+  color: #1bb19d;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.practice-style-card__select {
+  display: block;
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.practice-style-card__select strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.practice-style-card__select span {
+  display: block;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #697386;
+}
+
+.practice-style-card.is-selected .practice-style-card__select span {
+  color: #4d8f86;
+}
+
+.practice-style-modal__footer {
+  display: flex;
+  justify-content: center;
+  padding: 48px 40px 36px;
+}
+
 @media (max-width: 900px) {
   .practice-modal {
     max-width: 92vw;
@@ -646,8 +787,29 @@
     padding: 32px 20px 22px;
   }
 
+  .practice-modal__header--style {
+    padding: 30px 20px 34px;
+  }
+
+  .practice-modal__header--style h2 {
+    font-size: 28px;
+  }
+
   .practice-modal__body {
     padding: 24px 20px 8px;
+  }
+
+  .practice-style-modal__body {
+    padding: 32px 24px 0;
+  }
+
+  .practice-style-grid {
+    gap: 14px;
+  }
+
+  .practice-style-card {
+    min-height: 138px;
+    padding: 20px 22px;
   }
 
   .practice-modal__section h3 {
@@ -662,5 +824,15 @@
 
   .practice-modal__footer {
     padding: 8px 20px 24px;
+  }
+
+  .practice-style-modal__footer {
+    padding: 34px 20px 28px;
+  }
+}
+
+@media (max-width: 560px) {
+  .practice-style-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/pages/practice/styles/PracticePage.css
+++ b/src/pages/practice/styles/PracticePage.css
@@ -724,7 +724,7 @@
   width: 100%;
   height: 100%;
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 2.6;
   stroke-linecap: round;
   stroke-linejoin: round;

--- a/src/pages/practice/types.ts
+++ b/src/pages/practice/types.ts
@@ -1,5 +1,6 @@
 export type PracticeStage =
   | "intro-modal"
+  | "style-modal"
   | "ready"
   | "recording"
   | "paused"
@@ -15,3 +16,5 @@ export type IntroFormState = {
   speechType: SpeechType | "";
   duration: string;
 };
+
+export type SpeechStyleId = "passionate" | "intellectual" | "calm" | "dynamic";


### PR DESCRIPTION
## 📌 작업 내용
- intro-modal -> style-modal 화면 추가 

## 🔗 관련 이슈
- close #23 

## 🧪 테스트 방법
- [ ] npm run dev
- [ ] 주요 페이지 확인

## ✅ 체크리스트
- [ ] 빌드 에러 없음
- [ ] 코드 컨벤션 준수
- [ ] 불필요한 콘솔 제거

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/22cdf25a-6547-46d8-b3ce-04f0ede62058



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new speech style selection step in the practice workflow, positioned after the introduction
  * Users can now preview and select from four speech styles: passionate, intellectual, calm, and dynamic
  * Updated practice flow navigation with "Next" button progression through introduction and style selection stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->