### PR TITLE
feat: 발표 종료 분석 리포트 연동

### DIFF
--- a/src/api/practice.ts
+++ b/src/api/practice.ts
@@ -59,6 +59,14 @@ export type InputPracticeInfoResponse = {
   styleList: SpeechStyle[];
 };
 
+export type StopPracticeResponse = {
+  practiceId: number;
+  status: "ANALYZING" | "ANALYZED" | string;
+  audioUrl: string;
+};
+
+export type PracticeReportResponse = Record<string, unknown>;
+
 const AUDIO_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
   "audio/mp4": "mp4",
   "audio/mpeg": "mp3",
@@ -128,13 +136,21 @@ export async function stopPractice(
   time: number,
 ) {
   const formData = new FormData();
-  formData.append("audio", audio, getAudioFileName(audio));
+  formData.append("file", audio, getAudioFileName(audio));
   formData.append("time", String(time));
 
-  const { data } = await api.post<ApiResponse<ScriptResponse>>(
+  const { data } = await api.post<ApiResponse<StopPracticeResponse>>(
     `/api/practices/${practiceId}/stop`,
     formData,
   );
 
   return unwrapResponse(data, "연습 종료 요청에 실패했습니다.");
+}
+
+export async function getPracticeReport(practiceId: number) {
+  const { data } = await api.get<ApiResponse<PracticeReportResponse>>(
+    `/api/practices/${practiceId}/report`,
+  );
+
+  return unwrapResponse(data, "분석 리포트를 불러오지 못했습니다.");
 }

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -2,14 +2,17 @@ export type ApiResponse<T> = {
   code?: string;
   message?: string;
   result?: T;
-  success: boolean;
+  success?: boolean;
+  isSuccess?: boolean;
 };
 
 export function unwrapResponse<T>(
   response: ApiResponse<T>,
   fallbackMessage: string,
 ) {
-  if (!response.success || response.result === undefined || response.result === null) {
+  const isSuccess = response.success ?? response.isSuccess;
+
+  if (!isSuccess || response.result === undefined || response.result === null) {
     throw new Error(response.message || fallbackMessage);
   }
 

--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -12,17 +12,21 @@ import PracticeStyleModal from "./components/PracticeStyleModal";
 import useAudioMeter from "./hooks/useAudioMeter";
 import usePracticeRealtime from "./hooks/usePracticeRealtime";
 import {
+  getPracticeReport,
   inputPracticeInfo,
   selectPracticeStyle,
   startPractice as requestStartPractice,
   stopPractice,
+  type PracticeReportResponse,
   type SpeechStyle,
 } from "../../api/practice";
 import { getScript } from "../../api/scripts";
 import type {
   FeedbackIssue,
+  FeedbackMetric,
   FeedbackMetricId,
   IntroFormState,
+  PracticeFeedbackReport,
   PracticeRouteState,
   PracticeStage,
   SpeechStyleId,
@@ -67,7 +71,50 @@ const getStoredPracticeRouteState = () => {
   }
 };
 
-const feedbackIssues: FeedbackIssue[] = [
+const DEFAULT_FEEDBACK_METRICS: FeedbackMetric[] = [
+  {
+    id: "speech-rate",
+    label: "발화 속도",
+    value: "조금 느림",
+    badge: "90wpm",
+    initial: "S",
+    tone: "slate",
+  },
+  {
+    id: "voice-energy",
+    label: "음성 에너지",
+    value: "낮음",
+    badge: "에너지 부족",
+    initial: "E",
+    tone: "amber",
+  },
+  {
+    id: "pause",
+    label: "멈춤 구간",
+    value: "주의",
+    badge: "2초+ 멈춤",
+    initial: "P",
+    tone: "amber",
+  },
+  {
+    id: "emphasis",
+    label: "강조 표현",
+    value: "낮음",
+    badge: "강조 부족",
+    initial: "M",
+    tone: "violet",
+  },
+  {
+    id: "clarity",
+    label: "발음 명료도",
+    value: "불명확",
+    badge: "ZCR 0.08",
+    initial: "M",
+    tone: "green",
+  },
+];
+
+const DEFAULT_FEEDBACK_ISSUES: FeedbackIssue[] = [
   {
     metricId: "speech-rate",
     excerpt: "발표를 준비할 때 대부분의 사람들은 내용 위주로만 연습하고,",
@@ -104,6 +151,16 @@ const feedbackIssues: FeedbackIssue[] = [
       "긴 나열 문장은 단어 사이를 조금 더 또렷하게 끊어 말하면 인식률과 전달력이 함께 좋아집니다.",
   },
 ];
+
+const DEFAULT_FEEDBACK_REPORT: PracticeFeedbackReport = {
+  script: SCRIPT_TEXT,
+  goalPercent: 67,
+  summary:
+    "전반적으로 안정적인 발화였지만, 강조 표현과 발음 명료도가 부족해 전달력이 다소 약하게 느껴졌습니다.",
+  tip: "핵심 키워드를 더 강조하고 문장 끝에서 짧게 멈추면 전달력이 좋아집니다.",
+  metrics: DEFAULT_FEEDBACK_METRICS,
+  issues: DEFAULT_FEEDBACK_ISSUES,
+};
 
 function mapAudienceAge(value: IntroFormState["audienceAge"]) {
   switch (value) {
@@ -150,6 +207,157 @@ function mapSpeechType(value: IntroFormState["speechType"]) {
   }
 }
 
+function getRecordValue(source: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null && value !== "") return value;
+  }
+
+  return undefined;
+}
+
+function getStringValue(source: Record<string, unknown>, keys: string[]) {
+  const value = getRecordValue(source, keys);
+  return typeof value === "string" ? value : undefined;
+}
+
+function getNumberValue(source: Record<string, unknown>, keys: string[]) {
+  const value = getRecordValue(source, keys);
+
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function getRecordArray(source: Record<string, unknown>, keys: string[]) {
+  const value = getRecordValue(source, keys);
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => {
+        return typeof item === "object" && item !== null;
+      })
+    : [];
+}
+
+function mapMetricId(value: unknown, fallbackIndex: number): FeedbackMetricId {
+  const normalized = String(value ?? "").toLowerCase();
+
+  if (normalized.includes("voice") || normalized.includes("energy")) {
+    return "voice-energy";
+  }
+  if (normalized.includes("pause") || normalized.includes("silence")) {
+    return "pause";
+  }
+  if (normalized.includes("emphasis")) return "emphasis";
+  if (normalized.includes("clarity") || normalized.includes("pronunciation")) {
+    return "clarity";
+  }
+  if (normalized.includes("wpm") || normalized.includes("rate")) {
+    return "speech-rate";
+  }
+
+  return DEFAULT_FEEDBACK_METRICS[fallbackIndex]?.id ?? "speech-rate";
+}
+
+function mapPracticeReport(
+  report: PracticeReportResponse,
+  fallbackScript: string,
+): PracticeFeedbackReport {
+  const metricRows = getRecordArray(report, [
+    "metrics",
+    "metricList",
+    "analysisMetrics",
+    "analysisResults",
+  ]);
+  const issueRows = getRecordArray(report, [
+    "issues",
+    "feedbacks",
+    "feedbackList",
+    "sectionFeedbacks",
+    "sections",
+  ]);
+
+  const metrics =
+    metricRows.length > 0
+      ? metricRows.map((metric, index): FeedbackMetric => {
+          const fallback = DEFAULT_FEEDBACK_METRICS[index] ?? DEFAULT_FEEDBACK_METRICS[0];
+          const id = mapMetricId(
+            getRecordValue(metric, ["id", "metricId", "type", "metricType", "name"]),
+            index,
+          );
+
+          return {
+            id,
+            label:
+              getStringValue(metric, ["label", "name", "title", "metricName"]) ??
+              fallback.label,
+            value:
+              getStringValue(metric, ["value", "status", "level", "result"]) ??
+              fallback.value,
+            badge:
+              getStringValue(metric, ["badge", "detail", "scoreText", "displayValue"]) ??
+              fallback.badge,
+            initial: fallback.initial,
+            tone: fallback.tone,
+          };
+        })
+      : DEFAULT_FEEDBACK_METRICS;
+
+  const issues =
+    issueRows.length > 0
+      ? issueRows.map((issue, index): FeedbackIssue => {
+          return {
+            metricId: mapMetricId(
+              getRecordValue(issue, ["metricId", "type", "metricType", "category"]),
+              index,
+            ),
+            excerpt:
+              getStringValue(issue, [
+                "excerpt",
+                "targetText",
+                "text",
+                "sentence",
+                "scriptSegment",
+              ]) ?? "",
+            title:
+              getStringValue(issue, ["title", "summary", "feedbackTitle"]) ??
+              "상세 피드백",
+            description:
+              getStringValue(issue, [
+                "description",
+                "content",
+                "feedback",
+                "message",
+                "comment",
+              ]) ?? "분석 결과를 확인해보세요.",
+          };
+        })
+      : DEFAULT_FEEDBACK_ISSUES;
+
+  return {
+    script:
+      getStringValue(report, ["script", "scriptContent", "transcript", "content"]) ??
+      fallbackScript,
+    goalPercent:
+      getNumberValue(report, [
+        "goalPercent",
+        "targetMatchRate",
+        "targetRate",
+        "score",
+        "totalScore",
+      ]) ?? DEFAULT_FEEDBACK_REPORT.goalPercent,
+    summary:
+      getStringValue(report, ["summary", "overallFeedback", "totalFeedback", "comment"]) ??
+      DEFAULT_FEEDBACK_REPORT.summary,
+    tip: getStringValue(report, ["tip", "recommendation", "advice"]) ?? DEFAULT_FEEDBACK_REPORT.tip,
+    metrics,
+    issues,
+  };
+}
+
 export default function PracticePage() {
   const location = useLocation();
   const routeState =
@@ -180,7 +388,11 @@ export default function PracticePage() {
   const [stylesError, setStylesError] = useState<string | null>(null);
   const [practiceError, setPracticeError] = useState<string | null>(null);
   const [isSubmittingPractice, setIsSubmittingPractice] = useState(false);
+  const [isFetchingReport, setIsFetchingReport] = useState(false);
+  const [feedbackReport, setFeedbackReport] =
+    useState<PracticeFeedbackReport | null>(null);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
+  const reportRequestedRef = useRef(false);
   const realtime = usePracticeRealtime();
   const displayedScript = isReadingMarksEnabled ? markedScript : practiceScript;
 
@@ -310,6 +522,7 @@ export default function PracticePage() {
       return "녹음 전";
     if (stage === "recording") return "녹음 중";
     if (stage === "paused") return "일시정지";
+    if (stage === "analyzing") return "분석 중";
     if (stage === "record-finished") return "녹음 완료";
     return "녹음 전";
   }, [stage]);
@@ -321,7 +534,7 @@ export default function PracticePage() {
     // - 현재는 UI placeholder만 표시
     if (stage === "recording") return "측정 중";
     if (stage === "paused") return "일시정지";
-    if (stage === "record-finished") return "분석 중";
+    if (stage === "analyzing" || stage === "record-finished") return "분석 중";
     return "--";
   }, [stage]);
 
@@ -408,6 +621,8 @@ export default function PracticePage() {
     setElapsedSeconds(0);
     setNextTriggerTime(maxSeconds);
     setPracticeError(null);
+    setFeedbackReport(null);
+    reportRequestedRef.current = false;
 
     const didStart = await hookStartRecording();
     if (!didStart) {
@@ -443,21 +658,79 @@ export default function PracticePage() {
     setStage("recording");
   };
 
+  useEffect(() => {
+    if (
+      !realtime.isAnalysisComplete ||
+      !practiceId ||
+      stage !== "analyzing" ||
+      isFetchingReport ||
+      reportRequestedRef.current
+    ) {
+      return;
+    }
+
+    const loadReport = async () => {
+      reportRequestedRef.current = true;
+      setIsFetchingReport(true);
+      setPracticeError(null);
+      realtime.disconnect();
+
+      try {
+        const report = await getPracticeReport(practiceId);
+        setFeedbackReport(mapPracticeReport(report, practiceScript));
+        setActiveFeedbackMetric(null);
+        setStage("record-finished");
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "분석 리포트를 불러오지 못했습니다.";
+        setPracticeError(message);
+      } finally {
+        setIsFetchingReport(false);
+      }
+    };
+
+    void loadReport();
+  }, [
+    isFetchingReport,
+    practiceId,
+    practiceScript,
+    realtime,
+    realtime.isAnalysisComplete,
+    stage,
+  ]);
+
   const handleFinishRecord = async () => {
     try {
       const finalBlob = await stopRecording();
       setActiveFeedbackMetric(null);
-      setStage("record-finished");
-      realtime.disconnect();
+      setStage("analyzing");
 
       if (practiceId && finalBlob) {
-        await stopPractice(practiceId, finalBlob, elapsedSeconds);
+        const result = await stopPractice(practiceId, finalBlob, elapsedSeconds);
+
+        if (["ANALYZED", "COMPLETED"].includes(result.status.toUpperCase())) {
+          reportRequestedRef.current = true;
+          realtime.disconnect();
+          setIsFetchingReport(true);
+          const report = await getPracticeReport(practiceId);
+          setFeedbackReport(mapPracticeReport(report, practiceScript));
+          setStage("record-finished");
+          setIsFetchingReport(false);
+        }
       }
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "녹음 종료 처리에 실패했습니다.";
       setPracticeError(message);
+      setIsFetchingReport(false);
     }
+  };
+
+  const displayedFeedbackReport = feedbackReport ?? {
+    ...DEFAULT_FEEDBACK_REPORT,
+    script: practiceScript,
   };
 
   return (
@@ -480,13 +753,17 @@ export default function PracticePage() {
             <>
               <FeedbackScriptPanel
                 title={practiceTitle}
-                script={practiceScript}
+                script={displayedFeedbackReport.script}
                 activeMetricId={activeFeedbackMetric}
-                issues={feedbackIssues}
+                issues={displayedFeedbackReport.issues}
               />
 
               <FeedbackMetricsPanel
                 activeMetricId={activeFeedbackMetric}
+                goalPercent={displayedFeedbackReport.goalPercent}
+                metrics={displayedFeedbackReport.metrics}
+                summary={displayedFeedbackReport.summary}
+                tip={displayedFeedbackReport.tip}
                 onSelectMetric={setActiveFeedbackMetric}
               />
             </>
@@ -539,12 +816,7 @@ export default function PracticePage() {
                 일시 정지
               </button>
 
-              <button
-                className="practice-page__btn practice-page__btn--primary"
-                onClick={handleFinishRecord}
-              >
-                발표 완료
-              </button>
+              <RecordButton onClick={handleFinishRecord} />
             </>
           )}
 
@@ -564,6 +836,16 @@ export default function PracticePage() {
                 발표 완료
               </button>
             </>
+          )}
+
+          {stage === "analyzing" && (
+            <button
+              className="practice-page__btn practice-page__btn--primary"
+              type="button"
+              disabled
+            >
+              {isFetchingReport ? "리포트 불러오는 중" : "분석 중"}
+            </button>
           )}
         </div>
 

--- a/src/pages/practice/components/FeedbackMetricsPanel.tsx
+++ b/src/pages/practice/components/FeedbackMetricsPanel.tsx
@@ -1,69 +1,25 @@
-import type { FeedbackMetricId } from "../types";
-
-type FeedbackMetric = {
-  id: FeedbackMetricId;
-  label: string;
-  value: string;
-  badge: string;
-  initial: string;
-  tone: "slate" | "amber" | "violet" | "green";
-};
+import type { FeedbackMetric, FeedbackMetricId } from "../types";
 
 type FeedbackMetricsPanelProps = {
   activeMetricId: FeedbackMetricId | null;
+  goalPercent: number;
+  metrics: FeedbackMetric[];
+  summary: string;
+  tip: string;
   onSelectMetric: (metricId: FeedbackMetricId) => void;
 };
 
-const feedbackMetrics: FeedbackMetric[] = [
-  {
-    id: "speech-rate",
-    label: "발화 속도",
-    value: "조금 느림",
-    badge: "90wpm",
-    initial: "S",
-    tone: "slate",
-  },
-  {
-    id: "voice-energy",
-    label: "음성 에너지",
-    value: "낮음",
-    badge: "에너지 부족",
-    initial: "E",
-    tone: "amber",
-  },
-  {
-    id: "pause",
-    label: "멈춤 구간",
-    value: "주의",
-    badge: "2초+ 멈춤",
-    initial: "P",
-    tone: "amber",
-  },
-  {
-    id: "emphasis",
-    label: "강조 표현",
-    value: "낮음",
-    badge: "강조 부족",
-    initial: "M",
-    tone: "violet",
-  },
-  {
-    id: "clarity",
-    label: "발음 명료도",
-    value: "불명확",
-    badge: "ZCR 0.08",
-    initial: "M",
-    tone: "green",
-  },
-];
-
 export default function FeedbackMetricsPanel({
   activeMetricId,
+  goalPercent,
+  metrics,
+  summary,
+  tip,
   onSelectMetric,
 }: FeedbackMetricsPanelProps) {
-  const goalPercent = 67;
+  const safeGoalPercent = Math.min(100, Math.max(0, goalPercent));
   const circumference = Math.PI * 84;
-  const strokeOffset = circumference - (goalPercent / 100) * circumference;
+  const strokeOffset = circumference - (safeGoalPercent / 100) * circumference;
 
   return (
     <aside className="feedback-metrics-panel">
@@ -99,21 +55,15 @@ export default function FeedbackMetricsPanel({
           </svg>
           <div>
             <span>목표치</span>
-            <strong>{goalPercent}%</strong>
+            <strong>{safeGoalPercent}%</strong>
           </div>
         </div>
 
-        <p>
-          전반적으로 안정적인 발화였지만,
-          <br />
-          강조 표현과 발음 명료도가 부족해 전달력이
-          <br />
-          다소 약하게 느껴졌습니다.
-        </p>
+        <p>{summary}</p>
       </section>
 
       <div className="feedback-metric-grid">
-        {feedbackMetrics.map((metric) => {
+        {metrics.map((metric) => {
           const isActive = activeMetricId === metric.id;
 
           return (
@@ -141,10 +91,7 @@ export default function FeedbackMetricsPanel({
 
         <div className="feedback-tip-card">
           <span className="feedback-tip-card__label">TIP</span>
-          <p>
-            핵심 키워드를 더 강조하고 문장 끝에서 짧게 멈추면 전달력이
-            좋아집니다.
-          </p>
+          <p>{tip}</p>
         </div>
       </div>
     </aside>

--- a/src/pages/practice/hooks/usePracticeRealtime.ts
+++ b/src/pages/practice/hooks/usePracticeRealtime.ts
@@ -7,6 +7,7 @@ type RealtimeStatus = "idle" | "connecting" | "connected" | "error";
 type RealtimeMessage = {
   highlight: RealtimeHighlight | null;
   transcript: string;
+  isAnalysisComplete: boolean;
 };
 
 type UsePracticeRealtimeResult = {
@@ -14,6 +15,7 @@ type UsePracticeRealtimeResult = {
   errorMessage: string | null;
   highlight: RealtimeHighlight | null;
   transcript: string;
+  isAnalysisComplete: boolean;
   connect: (practiceId: number, script: string) => void;
   sendAudioChunk: (chunk: Blob) => void;
   sendControl: (type: "pause" | "resume" | "stop") => void;
@@ -55,9 +57,28 @@ function asString(value: unknown) {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function isAnalysisCompletePayload(payload: Record<string, unknown>) {
+  const status = asString(payload.status)?.toUpperCase();
+  const type = asString(payload.type)?.toUpperCase();
+  const event = asString(payload.event)?.toUpperCase();
+  const message = asString(payload.message);
+
+  return (
+    status === "ANALYZED" ||
+    status === "COMPLETED" ||
+    type === "ANALYSIS_COMPLETE" ||
+    type === "ANALYSIS_COMPLETED" ||
+    event === "ANALYSIS_COMPLETE" ||
+    event === "ANALYSIS_COMPLETED" ||
+    message?.includes("분석완료") ||
+    message?.includes("분석 완료") ||
+    false
+  );
+}
+
 function parseRealtimeMessage(eventData: MessageEvent["data"]): RealtimeMessage {
   if (typeof eventData !== "string") {
-    return { highlight: null, transcript: "" };
+    return { highlight: null, transcript: "", isAnalysisComplete: false };
   }
 
   try {
@@ -93,11 +114,14 @@ function parseRealtimeMessage(eventData: MessageEvent["data"]): RealtimeMessage 
         asString(payload.text) ??
         asString(payload.partial) ??
         "",
+      isAnalysisComplete: isAnalysisCompletePayload(payload),
     };
   } catch {
     return {
       highlight: { text: eventData },
       transcript: eventData,
+      isAnalysisComplete:
+        eventData.includes("분석완료") || eventData.includes("분석 완료"),
     };
   }
 }
@@ -107,6 +131,7 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [highlight, setHighlight] = useState<RealtimeHighlight | null>(null);
   const [transcript, setTranscript] = useState("");
+  const [isAnalysisComplete, setIsAnalysisComplete] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
 
   const sendControl = useCallback((type: "pause" | "resume" | "stop") => {
@@ -144,6 +169,7 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
       setErrorMessage(null);
       setHighlight(null);
       setTranscript("");
+      setIsAnalysisComplete(false);
 
       const socket = new WebSocket(wsUrl);
       socket.binaryType = "arraybuffer";
@@ -158,6 +184,9 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
         const message = parseRealtimeMessage(event.data);
         setTranscript(message.transcript);
         setHighlight(message.highlight);
+        if (message.isAnalysisComplete) {
+          setIsAnalysisComplete(true);
+        }
       };
 
       socket.onerror = () => {
@@ -189,6 +218,7 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
     errorMessage,
     highlight,
     transcript,
+    isAnalysisComplete,
     connect,
     sendAudioChunk,
     sendControl,

--- a/src/pages/practice/styles/PracticePage.css
+++ b/src/pages/practice/styles/PracticePage.css
@@ -367,7 +367,12 @@
   bottom: 40px;
   z-index: 100;
   display: flex;
+  align-items: center;
   gap: 12px;
+}
+
+.practice-page__record-controls .record-button-wrap {
+  position: static;
 }
 
 .practice-page__recording-error {

--- a/src/pages/practice/types.ts
+++ b/src/pages/practice/types.ts
@@ -4,6 +4,7 @@ export type PracticeStage =
   | "ready"
   | "recording"
   | "paused"
+  | "analyzing"
   | "record-finished";
 
 export type AudienceAge = "어린이" | "청소년" | "성인" | "노년";
@@ -38,6 +39,24 @@ export type FeedbackIssue = {
   excerpt: string;
   title: string;
   description: string;
+};
+
+export type FeedbackMetric = {
+  id: FeedbackMetricId;
+  label: string;
+  value: string;
+  badge: string;
+  initial: string;
+  tone: "slate" | "amber" | "violet" | "green";
+};
+
+export type PracticeFeedbackReport = {
+  script: string;
+  goalPercent: number;
+  summary: string;
+  tip: string;
+  metrics: FeedbackMetric[];
+  issues: FeedbackIssue[];
 };
 
 export type RealtimeHighlight = {


### PR DESCRIPTION
## 📌 작업 내용

- 종료 업로드 FormData 키를 스펙대로 file, time으로 맞춤
- 종료 응답 타입을 ANALYZING 포함 스펙에 맞게 변경
- 분석 완료 웹소켓 메시지 감지 후 웹소켓 종료
- GET /api/practices/{practiceId}/report 호출 추가
- report 결과를 피드백 화면의 지표, 목표치, 총평, TIP, 구간 피드백에 반영
- 녹음 중 다시 녹음 버튼을 누르면 종료 흐름으로 들어가게 변경
- isSuccess 응답 래퍼도 처리 가능하게 수정

## 🔗 관련 이슈
- close #58

## 🧪 테스트 방법
- [ ] npm run dev
- [ ] 주요 페이지 확인

## ✅ 체크리스트
- [ ] 빌드 에러 없음
- [ ] 코드 컨벤션 준수
- [ ] 불필요한 콘솔 제거

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice analysis now automatically fetches and displays detailed reports upon completion.
  * Added real-time tracking of analysis status with improved user feedback during processing.

* **Bug Fixes**
  * Improved handling of feedback data mapping and response parsing.
  * Fixed record control alignment and positioning.

* **Refactor**
  * Enhanced metrics panel to render dynamic data instead of static content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->