### PR TITLE
Fix: api 연결 수정 

### DIFF
--- a/src/api/practice.ts
+++ b/src/api/practice.ts
@@ -72,6 +72,39 @@ export type SelectPracticeStyleResponse = {
   contentList: PracticeContentItem[];
 };
 
+export type StartPracticeSentence = {
+  scriptSentenceId: number;
+  sentenceIndex: number;
+  originalText: string;
+  normalizedText: string;
+  startCharIndex: number;
+  endCharIndex: number;
+  words: StartPracticeWord[];
+};
+
+export type StartPracticeWord = {
+  scriptWordId: number;
+  scriptSentenceId: number;
+  sentenceIndex: number;
+  globalWordIndex: number;
+  sentenceWordIndex: number;
+  text: string;
+  normalizedText: string;
+  startCharIndex: number;
+  endCharIndex: number;
+};
+
+export type StartPracticeResponse = {
+  practiceId: number;
+  title: string;
+  webSocketUrl?: string;
+  status: string;
+  contentList: PracticeContentItem[];
+  sentences: StartPracticeSentence[];
+  scriptWords: StartPracticeWord[];
+  createdAt?: string;
+};
+
 export type StopPracticeResponse = {
   practiceId: number;
   status: "ANALYZING" | "ANALYZED" | string;
@@ -202,7 +235,7 @@ export async function selectPracticeStyle(practiceId: number, styleId: number) {
 }
 
 export async function startPractice(practiceId: number) {
-  const { data } = await api.post<ApiResponse<ScriptResponse>>(
+  const { data } = await api.post<ApiResponse<StartPracticeResponse>>(
     `/api/practices/${practiceId}`,
   );
 

--- a/src/api/practice.ts
+++ b/src/api/practice.ts
@@ -59,6 +59,19 @@ export type InputPracticeInfoResponse = {
   styleList: SpeechStyle[];
 };
 
+export type PracticeContentItem = {
+  index: number;
+  word: string;
+  hasBreak: boolean;
+  isEmphasis: boolean;
+};
+
+export type SelectPracticeStyleResponse = {
+  practiceId: number;
+  styleType: StyleType;
+  contentList: PracticeContentItem[];
+};
+
 export type StopPracticeResponse = {
   practiceId: number;
   status: "ANALYZING" | "ANALYZED" | string;
@@ -180,7 +193,7 @@ export async function getSpeechStyles() {
 }
 
 export async function selectPracticeStyle(practiceId: number, styleId: number) {
-  const { data } = await api.post<ApiResponse<ScriptResponse>>(
+  const { data } = await api.post<ApiResponse<SelectPracticeStyleResponse>>(
     `/api/practices/${practiceId}/select-style`,
     { styleId },
   );

--- a/src/api/practice.ts
+++ b/src/api/practice.ts
@@ -66,16 +66,26 @@ export type StopPracticeResponse = {
 };
 
 export type PracticeAnalysisResult = {
-  avgWpm?: number;
-  avgPitch?: number;
-  avgIntensity?: number;
-  avgZcr?: number;
-  pauseRatio?: number;
-  wpmDiff?: number;
-  pitchDiff?: number;
-  intensityDiff?: number;
-  zcrDiff?: number;
-  pauseCount?: number;
+  wpm?: {
+    avg?: number;
+    diff?: number;
+  };
+  pitch?: {
+    avg?: number;
+    diff?: number;
+  };
+  intensity?: {
+    avg?: number;
+    diff?: number;
+  };
+  zcr?: {
+    avg?: number;
+    diff?: number;
+  };
+  pause?: {
+    ratio?: number;
+    count?: number;
+  };
 };
 
 export type PracticeAiAnalysisResult = {
@@ -102,22 +112,23 @@ export type PracticeIssueResponse = {
 
 export type PracticeSentenceResponse = {
   index: number;
-  text: string;
+  text?: string;
+  originalText?: string;
   startTime?: number;
   endTime?: number;
   status?: string;
 };
 
 export type PracticeReportResponse = {
-  id: number;
+  practiceId: number;
   audioUrl?: string;
   time?: number;
   status?: string;
   audienceType?: AudienceType;
   audienceUnderstanding?: AudienceUnderstanding;
   speechInformation?: SpeechInformation;
-  analysisResult?: PracticeAnalysisResult;
-  aiAnalysisResult?: PracticeAiAnalysisResult;
+  analysis?: PracticeAnalysisResult;
+  aiAnalysis?: PracticeAiAnalysisResult;
   practiceIssues?: PracticeIssueResponse[];
   sentences?: PracticeSentenceResponse[];
 };

--- a/src/api/scripts.ts
+++ b/src/api/scripts.ts
@@ -1,11 +1,6 @@
 import { api } from "./http";
-
-type ApiResponse<T> = {
-  code?: string;
-  message?: string;
-  result?: T;
-  success: boolean;
-};
+import type { ApiResponse } from "./response";
+import { unwrapResponse } from "./response";
 
 export type AudienceAgeCode = "SENIOR" | "ADULT" | "YOUTH" | "CHILD";
 export type AudienceLevelCode = "LOW" | "MIDDLE" | "HIGH";
@@ -57,14 +52,6 @@ export type InputPracticeInfoRequest = {
   speechInformation: SpeechTypeCode;
   targetTime: number;
 };
-
-function unwrapResponse<T>(response: ApiResponse<T>, fallbackMessage: string) {
-  if (!response.success || !response.result) {
-    throw new Error(response.message || fallbackMessage);
-  }
-
-  return response.result;
-}
 
 export async function getScripts() {
   const { data } = await api.get<ApiResponse<ScriptResponse[]>>("/api/scripts");

--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -288,44 +288,47 @@ function getSentenceExcerpt(
     sentences.find((item) => item.index === startIndex + 1) ??
     sentences.find((item) => item.index === startIndex - 1);
 
-  return sentence?.text ?? "";
+  return sentence?.text ?? sentence?.originalText ?? "";
 }
 
 function mapPracticeReport(
   report: PracticeReportResponse,
   fallbackScript: string,
 ): PracticeFeedbackReport {
-  const analysis = report.analysisResult;
-  const aiAnalysis = report.aiAnalysisResult;
+  const analysis = report.analysis;
+  const aiAnalysis = report.aiAnalysis;
   const sentences = getSortedSentences(report.sentences);
-  const scriptFromSentences = sentences.map((sentence) => sentence.text).join("\n");
+  const scriptFromSentences = sentences
+    .map((sentence) => sentence.text ?? sentence.originalText ?? "")
+    .filter(Boolean)
+    .join("\n");
   const metrics: FeedbackMetric[] = [
     {
       ...getFallbackMetric(0),
       value:
         aiAnalysis?.wpmSummary ??
-        formatDiff(analysis?.wpmDiff, "wpm") ??
+        formatDiff(analysis?.wpm?.diff, "wpm") ??
         "분석 완료",
-      badge: formatNumber(analysis?.avgWpm, "wpm", 0) ?? getFallbackMetric(0).badge,
+      badge: formatNumber(analysis?.wpm?.avg, "wpm", 0) ?? getFallbackMetric(0).badge,
     },
     {
       ...getFallbackMetric(1),
       value:
         aiAnalysis?.energySummary ??
-        formatDiff(analysis?.intensityDiff, "dB") ??
+        formatDiff(analysis?.intensity?.diff, "dB") ??
         "분석 완료",
       badge:
-        formatNumber(analysis?.avgIntensity, "dB") ?? getFallbackMetric(1).badge,
+        formatNumber(analysis?.intensity?.avg, "dB") ?? getFallbackMetric(1).badge,
     },
     {
       ...getFallbackMetric(2),
       value:
-        analysis?.pauseCount !== undefined
-          ? `${analysis.pauseCount}회`
+        analysis?.pause?.count !== undefined
+          ? `${analysis.pause.count}회`
           : "분석 완료",
       badge:
         formatNumber(
-          analysis?.pauseRatio === undefined ? undefined : analysis.pauseRatio * 100,
+          analysis?.pause?.ratio === undefined ? undefined : analysis.pause.ratio * 100,
           "%",
         ) ?? getFallbackMetric(2).badge,
     },
@@ -336,8 +339,8 @@ function mapPracticeReport(
     },
     {
       ...getFallbackMetric(4),
-      value: formatDiff(analysis?.zcrDiff, "") ?? "분석 완료",
-      badge: formatNumber(analysis?.avgZcr, " ZCR", 3) ?? getFallbackMetric(4).badge,
+      value: formatDiff(analysis?.zcr?.diff, "") ?? "분석 완료",
+      badge: formatNumber(analysis?.zcr?.avg, " ZCR", 3) ?? getFallbackMetric(4).badge,
     },
   ];
 

--- a/src/pages/practice/PracticePage.tsx
+++ b/src/pages/practice/PracticePage.tsx
@@ -648,11 +648,10 @@ export default function PracticePage() {
       return;
     }
 
-    setStage("recording");
-    realtime.connect(practiceId, practiceScript);
-
     try {
-      await requestStartPractice(practiceId);
+      const practice = await requestStartPractice(practiceId);
+      setStage("recording");
+      realtime.connect(practiceId, practice.scriptWords);
     } catch (error) {
       await stopRecording();
       realtime.disconnect();

--- a/src/pages/practice/hooks/usePracticeRealtime.ts
+++ b/src/pages/practice/hooks/usePracticeRealtime.ts
@@ -36,8 +36,19 @@ function getRealtimeWsUrl(practiceId: number) {
   const token = getStoredAccessToken();
 
   url.protocol = url.protocol.replace(/^http/, "ws");
+  const basePath = url.pathname.replace(/\/$/, "");
 
-  url.searchParams.set("practiceId", String(practiceId));
+  if (/\/ws\/practice\/[^/]+$/.test(basePath)) {
+    url.pathname = basePath.replace(
+      /\/ws\/practice\/[^/]+$/,
+      `/ws/practice/${practiceId}`,
+    );
+  } else if (basePath.endsWith("/ws/practice")) {
+    url.pathname = `${basePath}/${practiceId}`;
+  } else {
+    url.pathname = `${basePath}/ws/practice/${practiceId}`.replace(/^\/\//, "/");
+  }
+
   if (token) url.searchParams.set("token", token);
 
   return url.toString();

--- a/src/pages/practice/hooks/usePracticeRealtime.ts
+++ b/src/pages/practice/hooks/usePracticeRealtime.ts
@@ -10,13 +10,25 @@ type RealtimeMessage = {
   isAnalysisComplete: boolean;
 };
 
+type RealtimeScriptWord = {
+  scriptWordId: number;
+  scriptSentenceId: number;
+  sentenceIndex: number;
+  globalWordIndex: number;
+  sentenceWordIndex: number;
+  text: string;
+  normalizedText: string;
+  startCharIndex: number;
+  endCharIndex: number;
+};
+
 type UsePracticeRealtimeResult = {
   status: RealtimeStatus;
   errorMessage: string | null;
   highlight: RealtimeHighlight | null;
   transcript: string;
   isAnalysisComplete: boolean;
-  connect: (practiceId: number, script: string) => void;
+  connect: (practiceId: number, scriptWords: RealtimeScriptWord[]) => void;
   sendAudioChunk: (chunk: Blob) => void;
   sendControl: (type: "pause" | "resume" | "stop") => void;
   disconnect: () => void;
@@ -166,7 +178,7 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
   }, []);
 
   const connect = useCallback(
-    (practiceId: number, script: string) => {
+    (practiceId: number, scriptWords: RealtimeScriptWord[]) => {
       disconnect();
 
       const wsUrl = getRealtimeWsUrl(practiceId);
@@ -188,7 +200,7 @@ export default function usePracticeRealtime(): UsePracticeRealtimeResult {
 
       socket.onopen = () => {
         setStatus("connected");
-        socket.send(JSON.stringify({ type: "start", practiceId, script }));
+        socket.send(JSON.stringify({ type: "init", practiceId, scriptWords }));
       };
 
       socket.onmessage = (event) => {


### PR DESCRIPTION
## 📌 작업 내용

- 스크립트 API 백엔드의 isSuccess 응답값 수정
- 연습 리포트 응답 타입 수정
- 연습 결과 화면에서 리포트 통계와 AI 분석값을 새 응답 구조대로 매핑하도록 수정
- 스피치 스타일 선택 API 응답 타입을 백엔드의 practiceId, styleType, contentList 구조로 수정
- 연습 시작 API 응답 타입을 백엔드의 webSocketUrl, sentences, scriptWords 포함 구조로 수정
- 실시간 분석 WebSocket 주소가 /ws/practice/{practiceId} 경로로 생성되도록 수정
- WebSocket 초기화 메시지를 백엔드가 처리하는 init 타입으로 바꾸고 scriptWords를 함께 전달하도록 수정

## 🔗 관련 이슈
- close #64 

## 🧪 테스트 방법
- [ ] npm run dev
- [ ] 주요 페이지 확인

## ✅ 체크리스트
- [ ] 빌드 에러 없음
- [ ] 코드 컨벤션 준수
- [ ] 불필요한 콘솔 제거

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured practice analytics metrics to use nested data organization for improved clarity.
  * Updated practice reporting format for better data consistency.
  * Optimized real-time recording communication protocol with enhanced data structure.
  * Refactored API response handling for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->