### PR TITLE
Fix: 온보딩에서 다음에 하기 시 로그인 처리

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,13 +1,13 @@
 import { api } from "./http";
 import {
+  clearAuthSession as clearStoredAuthSession,
+  getStoredUser as getStoredAuthUser,
   saveAuthSession as persistAuthSession,
   type StoredUserInfo,
 } from "./authStorage";
 import type { ApiResponse } from "./response";
 import { unwrapResponse } from "./response";
 
-const ACCESS_TOKEN_KEY = "speakfit_access_token";
-const USER_KEY = "speakfit_user";
 const VOICE_ONBOARDING_SEEN_KEY_PREFIX = "speakfit_voice_onboarding_seen";
 
 export type SignUpRequest = {
@@ -62,24 +62,11 @@ export function saveAuthSession(auth: LoginResponse, keepLogin: boolean) {
 }
 
 export function getStoredUser(): StoredUserInfo | null {
-  const raw = localStorage.getItem(USER_KEY) ?? sessionStorage.getItem(USER_KEY);
-
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(raw) as StoredUserInfo;
-  } catch {
-    return null;
-  }
+  return getStoredAuthUser();
 }
 
 export function clearAuthSession() {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(USER_KEY);
-  sessionStorage.removeItem(ACCESS_TOKEN_KEY);
-  sessionStorage.removeItem(USER_KEY);
+  clearStoredAuthSession();
 }
 
 function getVoiceOnboardingSeenKey(userId: number) {

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -1,8 +1,13 @@
 import Container from "../../../components/Container";
 import "../styles/hero.css";
+import { Link } from "react-router-dom";
+import { getStoredUser } from "../../../api/auth";
+import { ROUTES } from "../../../app/routes.const";
 import heroImage from "../../../assets/hero-image.png";
 
 export default function HeroSection() {
+  const user = getStoredUser();
+
   return (
     <section className="hero">
       <Container>
@@ -10,10 +15,25 @@ export default function HeroSection() {
           <h1 className="hero__title">
             어떤 무대에서도 당당하게, SpeakFit과 함께
           </h1>
-          <p className="hero__description">
+          <p
+            className={`hero__description${
+              user ? "" : " hero__description--spaced"
+            }`}
+          >
             AI 기반 발표 분석으로 당신의 발표를 객관적으로 진단하고, 더 나은
             발표를 위한 개선점을 제공합니다.
           </p>
+
+          {user && (
+            <div className="hero__actions">
+              <Link
+                className="btn btn-primary hero__primary-btn"
+                to={ROUTES.SCRIPT}
+              >
+                연습 시작
+              </Link>
+            </div>
+          )}
         </div>
         <div className="hero__image">
           <img src={heroImage} alt="SpeakFit 발표 분석 서비스" />

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -30,7 +30,7 @@ export default function HeroSection() {
                 className="btn btn-primary hero__primary-btn"
                 to={ROUTES.SCRIPT}
               >
-                연습 시작
+                발표 연습 시작하기
               </Link>
             </div>
           )}

--- a/src/pages/landing/components/HeroSection.tsx
+++ b/src/pages/landing/components/HeroSection.tsx
@@ -27,7 +27,7 @@ export default function HeroSection() {
           {user && (
             <div className="hero__actions">
               <Link
-                className="btn btn-primary hero__primary-btn"
+                className="btn hero__primary-btn"
                 to={ROUTES.SCRIPT}
               >
                 발표 연습 시작하기

--- a/src/pages/landing/components/LandingHeader.tsx
+++ b/src/pages/landing/components/LandingHeader.tsx
@@ -1,10 +1,20 @@
 import Container from "../../../components/Container";
 import "../styles/header.css";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { ROUTES } from "../../../app/routes.const";
+import { clearAuthSession, getStoredUser } from "../../../api/auth";
 import speakfitLogo from "../../../assets/speakfit-logo.png";
 
 export default function LandingHeader() {
+  const navigate = useNavigate();
+  const user = getStoredUser();
+  const displayName = user?.nickname?.trim() || "사용자";
+
+  const handleLogout = () => {
+    clearAuthSession();
+    navigate(ROUTES.LOGIN, { replace: true });
+  };
+
   return (
     <header className="landing-header">
       <Container className="landing-header__inner">
@@ -21,12 +31,30 @@ export default function LandingHeader() {
         </nav>
 
         <div className="landing-header__actions">
-          <Link className="btn btn-ghost" to={ROUTES.LOGIN}>
-            로그인
-          </Link>
-          <Link className="btn btn-primary" to={ROUTES.SIGNUP}>
-            회원가입
-          </Link>
+          {user ? (
+            <>
+              <span className="landing-header__user">{displayName}님</span>
+              <Link className="btn btn-primary" to={ROUTES.SCRIPT}>
+                연습 시작
+              </Link>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={handleLogout}
+              >
+                로그아웃
+              </button>
+            </>
+          ) : (
+            <>
+              <Link className="btn btn-ghost" to={ROUTES.LOGIN}>
+                로그인
+              </Link>
+              <Link className="btn btn-primary" to={ROUTES.SIGNUP}>
+                회원가입
+              </Link>
+            </>
+          )}
         </div>
       </Container>
     </header>

--- a/src/pages/landing/components/LandingHeader.tsx
+++ b/src/pages/landing/components/LandingHeader.tsx
@@ -34,9 +34,6 @@ export default function LandingHeader() {
           {user ? (
             <>
               <span className="landing-header__user">{displayName}님</span>
-              <Link className="btn btn-primary" to={ROUTES.SCRIPT}>
-                연습 시작
-              </Link>
               <button
                 type="button"
                 className="btn btn-ghost"

--- a/src/pages/landing/styles/header.css
+++ b/src/pages/landing/styles/header.css
@@ -52,8 +52,13 @@
 
 .landing-header__user {
   color: var(--color-text);
+  display: inline-block;
+  flex-shrink: 1;
   font-size: 14px;
   font-weight: 600;
+  max-width: min(28vw, 12rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/src/pages/landing/styles/header.css
+++ b/src/pages/landing/styles/header.css
@@ -34,6 +34,7 @@
 
 .landing-header__actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 10px;
 }
@@ -49,11 +50,11 @@
   font-weight: 700;
 }
 
-
-
-.landing-header__actions {
-  display: flex;
-  gap: 10px;
+.landing-header__user {
+  color: var(--color-text);
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 @media (max-width: 768px) {

--- a/src/pages/landing/styles/hero.css
+++ b/src/pages/landing/styles/hero.css
@@ -21,7 +21,11 @@
   font-size: 14px;
   line-height: 1.6;
   color: #666;
-  margin: 0 0 84px 0;
+  margin: 0 0 24px 0;
+}
+
+.hero__description--spaced {
+  margin-bottom: 84px;
 }
 
 .hero__actions {
@@ -29,7 +33,13 @@
   justify-content: center;
   gap: 12px;
   flex-wrap: wrap;
-  margin-bottom: 40px;
+  margin-bottom: 64px;
+}
+
+.hero__primary-btn {
+  min-width: 160px;
+  min-height: 52px;
+  font-size: 16px;
 }
 
 .hero__image {

--- a/src/pages/landing/styles/hero.css
+++ b/src/pages/landing/styles/hero.css
@@ -41,6 +41,7 @@
   min-height: 52px;
   font-size: 16px;
   background: #16b8a5;
+  color: #fff;
 }
 
 .hero__image {

--- a/src/pages/landing/styles/hero.css
+++ b/src/pages/landing/styles/hero.css
@@ -40,6 +40,7 @@
   min-width: 160px;
   min-height: 52px;
   font-size: 16px;
+  background: #16b8a5;
 }
 
 .hero__image {

--- a/src/pages/practice/styles/PracticePage.css
+++ b/src/pages/practice/styles/PracticePage.css
@@ -131,7 +131,11 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   background:
-    linear-gradient(180deg, rgba(244, 248, 252, 0.82) 0%, rgba(255, 255, 255, 0) 36px),
+    linear-gradient(
+      180deg,
+      rgba(244, 248, 252, 0.82) 0%,
+      rgba(255, 255, 255, 0) 36px
+    ),
     #ffffff;
 }
 
@@ -148,9 +152,10 @@
 .script-panel__word {
   display: inline;
   color: #202938; /* 읽기 전: 본문과 동일한 색상으로 일관성 유지 */
-  transition: background-color 0.4s cubic-bezier(0.25, 0.1, 0.25, 1), 
-              color 0.4s cubic-bezier(0.25, 0.1, 0.25, 1),
-              box-shadow 0.4s ease;
+  transition:
+    background-color 0.4s cubic-bezier(0.25, 0.1, 0.25, 1),
+    color 0.4s cubic-bezier(0.25, 0.1, 0.25, 1),
+    box-shadow 0.4s ease;
   margin-right: 0.25em;
   word-break: keep-all;
   border-radius: 6px;
@@ -531,7 +536,9 @@
   box-shadow: 0 18px 46px rgba(20, 28, 43, 0.22);
   z-index: 1000;
   white-space: normal;
-  transition: opacity 0.14s ease, visibility 0.14s ease;
+  transition:
+    opacity 0.14s ease,
+    visibility 0.14s ease;
 }
 
 .feedback-script-popover.is-visible {
@@ -681,6 +688,7 @@
   display: -webkit-box;
   overflow: hidden;
   -webkit-box-orient: vertical;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
 }
 
@@ -795,7 +803,9 @@
   box-shadow: 0 14px 34px rgba(25, 34, 50, 0.18);
   z-index: 20;
   word-break: keep-all;
-  transition: opacity 0.14s ease, visibility 0.14s ease;
+  transition:
+    opacity 0.14s ease,
+    visibility 0.14s ease;
 }
 
 .feedback-metric-card:hover .feedback-metric-card__feedback,
@@ -890,6 +900,7 @@
   display: -webkit-box;
   overflow: hidden;
   -webkit-box-orient: vertical;
+  line-clamp: 3;
   -webkit-line-clamp: 3;
 }
 


### PR DESCRIPTION
## 📌 작업 내용
- LandingHeader.tsx: 로그인된 사용자가 있으면 닉네임, 연습 시작, 로그아웃을 표시하도록 변경
- header.css: 로그인 사용자 표시 스타일 추가
- auth.ts: 사용자 조회/세션 삭제가 공통 authStorage 로직을 타도록 정리해서 토큰 만료 처리와 일관되게 동작하게 수정

## 🔗 관련 이슈
- close #75

## 🧪 테스트 방법
- [ ] npm run dev
- [ ] 주요 페이지 확인

## ✅ 체크리스트
- [ ] 빌드 에러 없음
- [ ] 코드 컨벤션 준수
- [ ] 불필요한 콘솔 제거

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Landing header now shows signed-in user name with a logout action; header and hero actions adjust based on sign-in state (start practice button shown when signed in).

* **Style**
  * Improved header alignment and user label styling; updated hero spacing and primary button sizing; enhanced practice page text clamping and transition formatting for clearer layout and readability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpeakFit/SpeakFit_FE/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->